### PR TITLE
fix: add Linux startup support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [1.3.1] - 2026-03-09
 
+### Bug Fixes
+- Add Linux support to `scripts/start_antigravity.sh` by launching the local `antigravity` binary instead of relying on macOS `open`
+- Improve startup diagnostics by waiting for CDP readiness and surfacing the Antigravity launcher log on failure
+- Handle bridge port collisions gracefully by reporting existing `/health` status instead of crashing with `OSError: [Errno 98]`
+
 ### Documentation
 - Add prominent risk warning (CAUTION block) to README — account ban risks, detection methods, safety guidelines
 - Respond to community question about account safety (Issue #1)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@
 ### 1. Install & Start
 
 ```bash
-# Install Antigravity from https://antigravity.com (macOS only)
+# Install Antigravity from https://antigravity.com
+# macOS: app bundle
+# Linux: install the desktop package so the `antigravity` launcher is on PATH
 
 # Clone this repo
 git clone https://github.com/ythx-101/antigravity-bridge.git
@@ -163,12 +165,12 @@ antigravity-bridge/
 ├── SKILL.md
 └── scripts/
     ├── bridge.py             # REST API server (v1.3.0)
-    └── start_antigravity.sh  # Mac startup helper
+    └── start_antigravity.sh  # macOS/Linux startup helper
 ```
 
 ## 📝 Requirements
 
-- macOS with [Antigravity](https://antigravity.com) installed
+- macOS or Linux with [Antigravity](https://antigravity.com) installed
 - Python 3.8+ with `websockets` package
 - Network access to `googleapis.com`
 

--- a/scripts/bridge.py
+++ b/scripts/bridge.py
@@ -1,4 +1,4 @@
-import json,asyncio,websockets,urllib.request,time,threading,re,argparse,uuid
+import json,asyncio,websockets,urllib.request,urllib.error,time,threading,re,argparse,uuid,sys
 from http.server import HTTPServer,BaseHTTPRequestHandler
 from urllib.parse import urlparse,parse_qs
 from collections import OrderedDict
@@ -362,8 +362,28 @@ class H(BaseHTTPRequestHandler):
     def log_message(s,*a):pass
 from socketserver import ThreadingMixIn
 class ThreadedHTTPServer(ThreadingMixIn,HTTPServer):daemon_threads=True
+
+def _existing_bridge_status(port):
+    try:
+        with urllib.request.urlopen(f'http://127.0.0.1:{port}/health',timeout=2) as r:
+            return json.loads(r.read())
+    except Exception:
+        return None
+
 if __name__=='__main__':
     pa=argparse.ArgumentParser();pa.add_argument('--port',type=int,default=19999);pa.add_argument('--cdp-port',type=int,default=9229)
     a=pa.parse_args();b=Bridge(a.cdp_port)
     print(f'AG Bridge v16 :{a.port}',flush=True)
-    ThreadedHTTPServer(('0.0.0.0',a.port),H).serve_forever()
+    try:
+        ThreadedHTTPServer(('0.0.0.0',a.port),H).serve_forever()
+    except OSError as e:
+        if e.errno==98:
+            print(f'Port {a.port} is already in use.',file=sys.stderr,flush=True)
+            status=_existing_bridge_status(a.port)
+            if status:
+                print(f'Existing bridge health: {json.dumps(status)}',file=sys.stderr,flush=True)
+                print('Use the running bridge, or stop it before starting a new one.',file=sys.stderr,flush=True)
+            else:
+                print('Another process is bound to that port. Stop it or choose a different --port.',file=sys.stderr,flush=True)
+            sys.exit(1)
+        raise

--- a/scripts/start_antigravity.sh
+++ b/scripts/start_antigravity.sh
@@ -1,27 +1,80 @@
 #!/bin/bash
 # start_antigravity.sh — Start Antigravity with CDP debug port and bridge server
-# Run on Mac: bash start_antigravity.sh
+# Run on macOS/Linux: bash start_antigravity.sh
 
 CDP_PORT=9229
 BRIDGE_PORT=19999
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ANTIGRAVITY_LOG=${ANTIGRAVITY_LOG:-/tmp/antigravity-cdp.log}
 
 # Kill existing instances
 killall mitmdump 2>/dev/null
 pkill -f 'antigravity_bridge\|bridge.py.*19999' 2>/dev/null
 
+is_cdp_ready() {
+    curl -s "http://127.0.0.1:$CDP_PORT/json/version" >/dev/null 2>&1
+}
+
+stop_antigravity() {
+    case "$(uname -s)" in
+        Darwin)
+            osascript -e 'tell application "Antigravity" to quit' 2>/dev/null || true
+            ;;
+        *)
+            pkill -x antigravity 2>/dev/null || true
+            pkill -f '/usr/share/antigravity/antigravity' 2>/dev/null || true
+            ;;
+    esac
+}
+
+start_antigravity() {
+    case "$(uname -s)" in
+        Darwin)
+            if ! command -v open >/dev/null 2>&1; then
+                echo "❌ macOS launcher 'open' not found"
+                return 1
+            fi
+            open -a Antigravity --args --remote-debugging-port="$CDP_PORT"
+            ;;
+        *)
+            if command -v antigravity >/dev/null 2>&1; then
+                nohup antigravity --remote-debugging-port="$CDP_PORT" \
+                    >"$ANTIGRAVITY_LOG" 2>&1 &
+            else
+                echo "❌ 'antigravity' launcher not found in PATH"
+                echo "   Install Antigravity or set PATH so the launcher is available."
+                return 1
+            fi
+            ;;
+    esac
+}
+
+wait_for_cdp() {
+    for _ in $(seq 1 20); do
+        if is_cdp_ready; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
 # Check if Antigravity is running with debug port
-if ! curl -s http://127.0.0.1:$CDP_PORT/json/version >/dev/null 2>&1; then
+if ! is_cdp_ready; then
     echo "Starting Antigravity with --remote-debugging-port=$CDP_PORT ..."
-    osascript -e 'tell application "Antigravity" to quit' 2>/dev/null
+    stop_antigravity
     sleep 3
-    open -a Antigravity --args --remote-debugging-port=$CDP_PORT
-    sleep 5
-    
-    if curl -s http://127.0.0.1:$CDP_PORT/json/version >/dev/null 2>&1; then
+    start_antigravity || exit 1
+
+    if wait_for_cdp; then
         echo "✅ Antigravity started with CDP on port $CDP_PORT"
     else
         echo "❌ Failed to start Antigravity with CDP"
+        if [ -f "$ANTIGRAVITY_LOG" ]; then
+            echo ""
+            echo "Last launcher log lines:"
+            tail -n 20 "$ANTIGRAVITY_LOG"
+        fi
         exit 1
     fi
 else


### PR DESCRIPTION
## Summary
- add Linux-aware startup logic to `scripts/start_antigravity.sh` while keeping the macOS path intact
- make `scripts/bridge.py` report existing healthy bridge instances instead of crashing on port collisions
- update README and changelog entries to reflect Linux support and the improved startup behavior

## Testing
- `bash -n scripts/start_antigravity.sh`
- `python3 -m py_compile scripts/bridge.py`
- `bash scripts/start_antigravity.sh` on Fedora (verified CDP on :9229 and bridge health on :19999)
- `python3 scripts/bridge.py` while the bridge was already running (verified clean port-in-use message)
